### PR TITLE
base_url isn't being applied

### DIFF
--- a/xmlsitemap.generate.inc
+++ b/xmlsitemap.generate.inc
@@ -160,10 +160,12 @@ function xmlsitemap_generate_chunk(stdClass $sitemap, XMLSitemapWriter $writer, 
   $url_options = $sitemap->uri['options'];
   $url_options += array(
     'absolute' => TRUE,
-    'base_url' => $config->get('base_url', $GLOBALS['base_url']),
+    //'base_url' => $config->get('base_url', $GLOBALS['base_url']),
     'language' => language_default(),
     'alias' => $config->get('prefetch_aliases', TRUE),
   );
+
+  $url_options['base_url'] = $config->get('base_url', $GLOBALS['base_url']);
 
   $last_url = '';
   $link_count = 0;


### PR DESCRIPTION
The `base_url` when specified in "Default base URL" under Advanced settings isn't being applied due to the way the array is being merged using the `+=` operator.  I'm not 100% sure what the purpose of using this method to merge the arrays is.  This 'fix' uses a similar workaround is present in `xmlsitemap.xmlsitemap.inc`.  I think a more appropriate approach would be to use array_merge() or just assign the overriding values to the elements individually.