### PR TITLE
Issue #101: Prevent PHP warning when upgrading from D7.

### DIFF
--- a/xmlsitemap_menu/xmlsitemap_menu.module
+++ b/xmlsitemap_menu/xmlsitemap_menu.module
@@ -48,16 +48,19 @@ function xmlsitemap_menu_entity_info_alter(&$info) {
       'token type' => 'menu_link',
     );
 
-    foreach (menu_get_menus() as $type => $name) {
-      $info['menu_link']['bundles'][$type] = array(
-        'label' => $name,
-        'admin' => array(
-          'path' => 'admin/structure/menu/manage/%menu/edit',
-          'bundle argument' => 4,
-          'real path' => 'admin/structure/menu/manage/' . $type . '/edit',
-          'access arguments' => array('administer menus'),
-        ),
-      );
+    $menus = menu_get_menus();
+    if (is_array($menus)) {
+      foreach ($menus as $type => $name) {
+        $info['menu_link']['bundles'][$type] = array(
+          'label' => $name,
+          'admin' => array(
+            'path' => 'admin/structure/menu/manage/%menu/edit',
+            'bundle argument' => 4,
+            'real path' => 'admin/structure/menu/manage/' . $type . '/edit',
+            'access arguments' => array('administer menus'),
+          ),
+        );
+      }
     }
   }
   else {


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/xmlsitemap/issues/101