### PR TITLE
Issue #105: Add quicksketch as co-maintainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ profiles.
 ## Current Maintainers
 
  - [Laryn Kragt Bakker](https://github.com/laryn) - [CEDC.org](https://cedc.org)
+ - [Nate Lampton](https://github.com/quicksketch)
  - Collaboration and co-maintainers welcome!
 
 ## Credits


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/xmlsitemap/issues/105