### PR TITLE
Issue #28, #29, #59, #104: Fix all failing XML Sitemap tests.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -43,4 +43,4 @@ jobs:
         run: core/scripts/install.sh --db-url=mysql://root:root@localhost/backdrop
 
       - name: Run functional tests
-        run: core/scripts/run-tests.sh --force --directory=modules/${{ env.REPO_NAME }} --verbose --concurrency=2
+        run: core/scripts/run-tests.sh --force --directory=modules/${{ env.REPO_NAME }} --verbose --color --concurrency=2

--- a/tests/xmlsitemap.test
+++ b/tests/xmlsitemap.test
@@ -36,7 +36,8 @@ class XMLSitemapTestHelper extends BackdropWebTestCase {
    */
   public function tearDown() {
     // Capture any (remaining) watchdog errors.
-    //$this->assertNoWatchdogErrors();
+    //$this->_assertNoWatchdogErrors();
+    $this->_getWatchdogMessages(array(), TRUE);
 
     parent::tearDown();
   }
@@ -156,7 +157,7 @@ class XMLSitemapTestHelper extends BackdropWebTestCase {
    */
   protected function assertSitemapLinkValues($entity_type, $entity_id, array $conditions) {
     $link = xmlsitemap_link_load($entity_type, $entity_id);
-
+debug($link);
     if (!$link) {
       return $this->fail(t('Could not load sitemap link for @type @id.', array(
         '@type' => $entity_type,
@@ -303,7 +304,7 @@ class XMLSitemapTestHelper extends BackdropWebTestCase {
    *
    * @todo Add unit tests for this function.
    */
-  protected function getWatchdogMessages(array $conditions = array(), $reset = FALSE) {
+  protected function _getWatchdogMessages(array $conditions = array(), $reset = FALSE) {
     static $seen_ids = array();
 
     if (!module_exists('dblog') || $reset) {
@@ -338,23 +339,29 @@ class XMLSitemapTestHelper extends BackdropWebTestCase {
 
   /**
    * Assert Watchdog Message.
+   *
+   * Customized version for XMLSitemap. Differs from core assertWatchdogMessage.
    */
-  protected function assertWatchdogMessage(array $conditions, $message = 'Watchdog message found.') {
-    $this->assertTrue($this->getWatchdogMessages($conditions), $message);
+  protected function _assertWatchdogMessage(array $conditions, $message = NULL) {
+    if (!isset($message)) {
+      $conditions += array('variables' => array());
+      $message = 'Watchdog message found: ' . format_string($conditions['message'], $conditions['variables']);
+    }
+    $this->assertTrue($this->_getWatchdogMessages($conditions), $message);
   }
 
   /**
    * Assert No Watchdog Message.
    */
-  protected function assertNoWatchdogMessage(array $conditions, $message = 'Watchdog message not found.') {
-    $this->assertFalse($this->getWatchdogMessages($conditions), $message);
+  protected function _assertNoWatchdogMessage(array $conditions, $message = 'Watchdog message not found.') {
+    $this->assertFalse($this->_getWatchdogMessages($conditions), $message);
   }
 
   /**
    * Check that there were no watchdog errors or worse.
    */
-  protected function assertNoWatchdogErrors() {
-    $messages = $this->getWatchdogMessages();
+  protected function _assertNoWatchdogErrors() {
+    $messages = $this->_getWatchdogMessages();
     $verbose = array();
 
     foreach ($messages as $message) {
@@ -375,9 +382,6 @@ class XMLSitemapTestHelper extends BackdropWebTestCase {
       array_unshift($verbose, '<h2>Watchdog messages</h2>');
       $this->verbose(implode("<br />", $verbose), 'Watchdog messages from test run');
     }
-
-    // Clear the seen watchdog messages since we've failed on any errors.
-    $this->getWatchdogMessages(array(), TRUE);
   }
 
   /**
@@ -617,47 +621,47 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
       'status' => 1,
     );
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['status'] = 0;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['priority'] = 0.5;
     $link['loc'] = 'new_location';
     $link['status'] = 1;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['priority'] = 0.0;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['priority'] = 0.1;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['priority'] = 1.0;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['priority'] = 1;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', FALSE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', FALSE);
 
     $link['priority'] = 0;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['priority'] = 0.5;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $link['priority'] = 0.5;
     $link['priority_override'] = 0;
     $link['status'] = 1;
     xmlsitemap_link_save($link);
-    $this->assertFlag('regenerate_needed', FALSE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', FALSE);
   }
 
   /**
@@ -677,12 +681,12 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
     $this->assertFalse(xmlsitemap_link_load($link1['type'], $link1['id']));
     $this->assertFalse(xmlsitemap_link_load($link2['type'], $link2['id']));
     $this->assertTrue(xmlsitemap_link_load($link3['type'], $link3['id']));
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
 
     $deleted = xmlsitemap_link_delete($link3['type'], $link3['id']);
     $this->assertEqual($deleted, 1);
     $this->assertFalse(xmlsitemap_link_load($link3['type'], $link3['id']));
-    $this->assertFlag('regenerate_needed', FALSE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', FALSE);
   }
 
   /**
@@ -705,7 +709,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
       'status_override' => 0,
     ));
     $this->assertEqual($updated, 2);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
     // Id | type    | subtype | language | status | priority
     // 1  | testing | group1  | ''       | 0      | 0.5
     // 2  | testing | group1  | ''       | 0      | 0.5
@@ -716,7 +720,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
       'priority_override' => 0,
     ));
     $this->assertEqual($updated, 2);
-    $this->assertFlag('regenerate_needed', FALSE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', FALSE);
     // Id | type    | subtype | language | status | priority
     // 1  | testing | group1  | ''       | 0      | 0.0
     // 2  | testing | group1  | ''       | 0      | 0.0
@@ -726,7 +730,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
       'subtype' => 'group1',
     ));
     $this->assertEqual($updated, 2);
-    $this->assertFlag('regenerate_needed', FALSE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', FALSE);
     // Id | type    | subtype | language | status | priority
     // 1  | testing | group2  | ''       | 0      | 0.0
     // 2  | testing | group2  | ''       | 0      | 0.0
@@ -738,7 +742,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
       'status' => 0,
     ));
     $this->assertEqual($updated, 2);
-    $this->assertFlag('regenerate_needed', TRUE);
+    $this->assertFlag('xmlsitemap_regenerate_needed', TRUE);
     // Id | type    | subtype | language | status | priority
     // 1  | testing | group2  | ''       | 1      | 0.0
     // 2  | testing | group2  | ''       | 1      | 0.0
@@ -769,7 +773,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
     $this->assertResponse(200);
     $this->assertNoRaw('lifetime-test');
 
-    config_set('xmlsitemap', 'generated_last', REQUEST_TIME - 400);
+    state_set('xmlsitemap_generated_last', REQUEST_TIME - 400);
     $this->cronRun();
     $this->backdropGetSitemap();
     $this->assertRaw('lifetime-test');
@@ -798,7 +802,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
     file_unmanaged_save_data('Test contents', 'public://xmlsitemap/test/index.xml');
 
     // Set the directory to an empty value.
-    variable_set('xmlsitemap_path', '');
+    config_set('xmlsitemap.settings', 'path', '');
     backdrop_static_reset('xmlsitemap_get_directory');
 
     // Test that nothing was deleted.
@@ -809,7 +813,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
     $this->assertFalse($result);
 
     // Reset the value back to the default.
-    variable_set('xmlsitemap_path', 'xmlsitemap');
+    config_set('xmlsitemap.settings', 'path', 'xmlsitemap');
     backdrop_static_reset('xmlsitemap_get_directory');
 
     // Test that only the xmlsitemap directory was deleted.
@@ -828,7 +832,7 @@ class XMLSitemapUnitTest extends XMLSitemapTestHelper {
     file_prepare_directory($directory, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
 
     // Update the directory path to a different value.
-    variable_set('xmlsitemap_path', 'test');
+    config_set('xmlsitemap.settings', 'path', 'test');
     backdrop_static_reset('xmlsitemap_get_directory');
 
     // Test that running uninstall removes the correct directory (test) and not the default (xmlsitemap)

--- a/tests/xmlsitemap.tests.info
+++ b/tests/xmlsitemap.tests.info
@@ -10,9 +10,9 @@ description = Functional tests for the XML sitemap module.
 group = XML sitemap
 file = xmlsitemap.test
 
-;[XMLSitemapRobotsTxtIntegrationTest]
-;name = XML sitemap robots.txt
-;description = Integration tests for the XML sitemap and robots.txt module.
-;group = XML sitemap
-;file = xmlsitemap.test
-;dependancies[] = robotstxt @todo
+[XMLSitemapRobotsTxtIntegrationTest]
+name = XML sitemap robots.txt
+description = Integration tests for the XML sitemap and robots.txt module.
+group = XML sitemap
+file = xmlsitemap.test
+dependencies[] = robotstxt

--- a/xmlsitemap.admin.inc
+++ b/xmlsitemap.admin.inc
@@ -164,7 +164,6 @@ function xmlsitemap_sitemap_list_form_submit($form, &$form_state) {
  * Edit Form.
  */
 function xmlsitemap_sitemap_edit_form(array $form, array &$form_state, stdClass $sitemap = NULL) {
-  _xmlsitemap_set_breadcrumb();
 
   if (!isset($sitemap)) {
     $sitemap = new stdClass();
@@ -244,7 +243,6 @@ function xmlsitemap_sitemap_edit_form_submit($form, &$form_state) {
  * Delete form.
  */
 function xmlsitemap_sitemap_delete_form(array $form, array &$form_state, stdClass $sitemap) {
-  _xmlsitemap_set_breadcrumb();
 
   $count = (int) db_query("SELECT COUNT(smid) FROM {xmlsitemap_sitemap}")->fetchField();
   if ($count === 1 && empty($_POST)) {

--- a/xmlsitemap.module
+++ b/xmlsitemap.module
@@ -926,6 +926,7 @@ function _xmlsitemap_delete_recursive($path, $delete_root = FALSE) {
   // Resolve streamwrapper URI to local path.
   $path = backdrop_realpath($path);
   if (is_dir($path)) {
+    // @codingStandardsIgnoreLine
     $dir = dir($path);
     while (($entry = $dir->read()) !== FALSE) {
       if ($entry == '.' || $entry == '..') {

--- a/xmlsitemap.module
+++ b/xmlsitemap.module
@@ -926,7 +926,7 @@ function _xmlsitemap_delete_recursive($path, $delete_root = FALSE) {
   // Resolve streamwrapper URI to local path.
   $path = backdrop_realpath($path);
   if (is_dir($path)) {
-    $dir = getdir($path);
+    $dir = dir($path);
     while (($entry = $dir->read()) !== FALSE) {
       if ($entry == '.' || $entry == '..') {
         continue;
@@ -1056,7 +1056,7 @@ function xmlsitemap_entity_query_alter($query) {
 }
 
 /**
- * Budle Settings.
+ * Bundle Settings.
  */
 function xmlsitemap_link_bundle_settings_save($entity, $bundle, array $settings, $update_links = TRUE) {
   if ($update_links) {

--- a/xmlsitemap_custom/tests/xmlsitemap_custom.test
+++ b/xmlsitemap_custom/tests/xmlsitemap_custom.test
@@ -4,6 +4,9 @@
  * Unit tests for the xmlsitemap_custom.
  */
 
+// Temporarily include the parent class until core provides test autoloading.
+include_once(__DIR__ . '/../../tests/xmlsitemap.test');
+
 /**
  * Class with Functional Test for XML Sitemap Custom.
  */

--- a/xmlsitemap_custom/xmlsitemap_custom.admin.inc
+++ b/xmlsitemap_custom/xmlsitemap_custom.admin.inc
@@ -69,7 +69,6 @@ function xmlsitemap_custom_list_links() {
  */
 function xmlsitemap_custom_edit_link_form($form, &$form_state, $link = array()) {
   module_load_include('inc', 'xmlsitemap', 'xmlsitemap.admin');
-  _xmlsitemap_set_breadcrumb('admin/config/search/xmlsitemap/custom');
 
   $link += array(
     'id' => db_query("SELECT MAX(id) FROM {xmlsitemap} WHERE type = 'custom'")->fetchField() + 1,

--- a/xmlsitemap_engines/tests/xmlsitemap_engines.test
+++ b/xmlsitemap_engines/tests/xmlsitemap_engines.test
@@ -4,6 +4,9 @@
  * Tests for the xmlsitemap_engines module.
  */
 
+// Temporarily include the parent class until core provides test autoloading.
+include_once(__DIR__ . '/../../tests/xmlsitemap.test');
+
 /**
  * Functional Test.
  *

--- a/xmlsitemap_engines/tests/xmlsitemap_engines.test
+++ b/xmlsitemap_engines/tests/xmlsitemap_engines.test
@@ -26,11 +26,6 @@ class XMLSitemapEnginesFunctionalTest extends XMLSitemapTestHelper {
     $this->admin_user = $this->backdropCreateUser(array('access content', 'administer xmlsitemap'));
     $this->backdropLogin($this->admin_user);
 
-    // @todo For some reason the test client does not have clean URLs while
-    // the test runner does, so it causes mismatches in watchdog assertions
-    // later.
-    config_set('system.core', 'clean_url', 0);
-
     $this->submit_url = url('ping', array('absolute' => TRUE, 'query' => array('sitemap' => ''))) . '[sitemap]';
   }
 
@@ -80,16 +75,16 @@ class XMLSitemapEnginesFunctionalTest extends XMLSitemapTestHelper {
     $sitemaps[] = $sitemap;
     xmlsitemap_engines_submit_sitemaps($this->submit_url, $sitemaps);
 
-    $this->assertWatchdogMessage(array(
+    $this->_assertWatchdogMessage(array(
       'type' => 'xmlsitemap',
-      'message' => 'Recieved ping for @sitemap.',
+      'message' => 'Received ping for @sitemap.',
       'variables' => array(
         '@sitemap' => 'http://example.com/sitemap.xml',
       ),
     ));
-    $this->assertWatchdogMessage(array(
+    $this->_assertWatchdogMessage(array(
       'type' => 'xmlsitemap',
-      'message' => 'Recieved ping for @sitemap.',
+      'message' => 'Received ping for @sitemap.',
       'variables' => array(
         '@sitemap' => 'http://example.com/sitemap-2.xml',
       ),
@@ -105,8 +100,23 @@ class XMLSitemapEnginesFunctionalTest extends XMLSitemapTestHelper {
     $this->assertText(t('The configuration options have been saved.'));
 
     $this->submitEngines();
-    $this->assertWatchdogMessage(array('type' => 'xmlsitemap', 'message' => 'Submitted the sitemap to %url and received response @code.'));
-    $this->assertWatchdogMessage(array('type' => 'xmlsitemap', 'message' => 'Recieved ping for @sitemap.'));
+    $sitemap_url = xmlsitemap_engines_prepare_url($this->submit_url, url('sitemap.xml', array('absolute' => TRUE)));
+
+    $this->_assertWatchdogMessage(array(
+      'type' => 'xmlsitemap',
+      'message' => 'Submitted the sitemap to %url and received response @code.',
+      'variables' => array(
+        '%url' => $sitemap_url,
+        '@code' => '200',
+      )
+    ));
+    $this->_assertWatchdogMessage(array(
+      'type' => 'xmlsitemap',
+      'message' => 'Received ping for @sitemap.',
+      'variables' => array(
+        '@sitemap' => url('sitemap.xml', array('absolute' => TRUE)),
+      )
+    ));
   }
 
   /**
@@ -127,7 +137,7 @@ class XMLSitemapEnginesFunctionalTest extends XMLSitemapTestHelper {
     $this->assertText(t('The configuration options have been saved.'));
 
     $this->submitEngines();
-    $this->assertWatchdogMessage(array(
+    $this->_assertWatchdogMessage(array(
       'type' => 'xmlsitemap',
       'message' => 'Submitted the sitemap to %url and received response @code.',
       'variables' => array(
@@ -135,8 +145,7 @@ class XMLSitemapEnginesFunctionalTest extends XMLSitemapTestHelper {
         '@code' => '404',
       ),
     ));
-    $this->assertWatchdogMessage(array('type' => 'xmlsitemap', 'message' => 'No valid sitemap parameter provided.'));
-    $this->assertWatchdogMessage(array('type' => 'page not found', 'message' => 'ping'));
+    $this->_assertWatchdogMessage(array('type' => 'xmlsitemap', 'message' => 'No valid sitemap parameter provided.'));
 
     $edit = array('engines_custom_urls' => $this->submit_url);
     $this->backdropPost('admin/config/search/xmlsitemap/engines', $edit, t('Save configuration'));
@@ -144,7 +153,7 @@ class XMLSitemapEnginesFunctionalTest extends XMLSitemapTestHelper {
 
     $this->submitEngines();
     $url = xmlsitemap_engines_prepare_url($this->submit_url, url('sitemap.xml', array('absolute' => TRUE)));
-    $this->assertWatchdogMessage(array(
+    $this->_assertWatchdogMessage(array(
       'type' => 'xmlsitemap',
       'message' => 'Submitted the sitemap to %url and received response @code.',
       'variables' => array(
@@ -152,9 +161,9 @@ class XMLSitemapEnginesFunctionalTest extends XMLSitemapTestHelper {
         '@code' => '200',
       ),
     ));
-    $this->assertWatchdogMessage(array(
+    $this->_assertWatchdogMessage(array(
       'type' => 'xmlsitemap',
-      'message' => 'Recieved ping for @sitemap.',
+      'message' => 'Received ping for @sitemap.',
       'variables' => array(
         '@sitemap' => url('sitemap.xml', array(
           'absolute' => TRUE,

--- a/xmlsitemap_engines/tests/xmlsitemap_engines_test.module
+++ b/xmlsitemap_engines/tests/xmlsitemap_engines_test.module
@@ -45,11 +45,16 @@ function xmlsitemap_engines_test_xmlsitemap_engine_info_alter(&$engines) {
  */
 function xmlsitemap_engines_test_pinged() {
   if (empty($_GET['sitemap']) || !valid_url($_GET['sitemap'])) {
-    watchdog('xmlsitemap', 'No valid sitemap parameter provided.', array(), WATCHDOG_WARNING);
-    // @todo Remove this? Causes an extra watchdog error to be handled.
-    return MENU_NOT_FOUND;
+    $message = 'No valid sitemap parameter provided.';
+    $variables = array();
+    watchdog('xmlsitemap', $message, $variables, WATCHDOG_WARNING);
+    backdrop_add_http_header('Status', '404 Not Found');
   }
   else {
-    watchdog('xmlsitemap', 'Recieved ping for @sitemap.', array('@sitemap' => $_GET['sitemap']));
+    $message = 'Received ping for @sitemap.';
+    $variables = array('@sitemap' => $_GET['sitemap']);
+    watchdog('xmlsitemap', $message, $variables);
   }
+  print format_string($message, $variables);
+  backdrop_exit();
 }

--- a/xmlsitemap_i18n/tests/xmlsitemap_i18n.test
+++ b/xmlsitemap_i18n/tests/xmlsitemap_i18n.test
@@ -4,6 +4,9 @@
  * Unit tests for the xmlsitemap_i18n project.
  */
 
+// Temporarily include the parent class until core provides test autoloading.
+include_once(__DIR__ . '/../../tests/xmlsitemap.test');
+
 /**
  * Common base test class for XML sitemap internationalization tests.
  */

--- a/xmlsitemap_menu/tests/xmlsitemap_menu.test
+++ b/xmlsitemap_menu/tests/xmlsitemap_menu.test
@@ -4,6 +4,9 @@
  * Unit tests for the xmlsitemap_menu project..
  */
 
+// Temporarily include the parent class until core provides test autoloading.
+include_once(__DIR__ . '/../../tests/xmlsitemap.test');
+
 /**
  * Menu Functional Test.
  */

--- a/xmlsitemap_node/tests/xmlsitemap_node.test
+++ b/xmlsitemap_node/tests/xmlsitemap_node.test
@@ -4,6 +4,9 @@
  * Unit tests for the xmlsitemap_node module.
  */
 
+// Temporarily include the parent class until core provides test autoloading.
+include_once(__DIR__ . '/../../tests/xmlsitemap.test');
+
 /**
  * Node Functional Test.
  */

--- a/xmlsitemap_node/tests/xmlsitemap_node.test
+++ b/xmlsitemap_node/tests/xmlsitemap_node.test
@@ -93,22 +93,30 @@ class XMLSitemapNodeFunctionalTest extends XMLSitemapTestHelper {
     $edit = array(
       'xmlsitemap[status]' => 0,
       'xmlsitemap[priority]' => 0.9,
-      'status' => TRUE,
+      'status' => 1,
     );
     $this->backdropPost('node/' . $node->nid . '/edit', $edit, t('Save'));
     $this->assertText('Page Test node title has been updated.');
+    // The access starts as 0 immediately, then is updated based on node
+    // grants on cron jobs.
     $this->assertSitemapLinkValues('node', $node->nid, array(
-      'access' => 1,
+      'access' => 0,
       'status' => 0,
       'priority' => 0.9,
       'status_override' => 1,
       'priority_override' => 1,
     ));
 
+    // Run cron to check status is updated after run.
+    $this->cronRun();
+    $this->assertSitemapLinkValues('node', $node->nid, array(
+      'access' => 1,
+    ));
+
     $edit = array(
       'xmlsitemap[status]' => 'default',
       'xmlsitemap[priority]' => 'default',
-      'status' => FALSE,
+      'status' => 0,
     );
     $this->backdropPost('node/' . $node->nid . '/edit', $edit, t('Save'));
     $this->assertText('Page Test node title has been updated.');
@@ -149,7 +157,7 @@ class XMLSitemapNodeFunctionalTest extends XMLSitemapTestHelper {
       'xmlsitemap[priority]' => '0.5',
     );
     $this->backdropPost('admin/structure/types/manage/page', $edit, t('Save content type'));
-    $this->assertText('Changed the content type of 2 posts from page to page2.');
+    $this->assertText('Changed the content type of 2 pieces of content from page to page2.');
     $this->assertText('The content type Page has been updated.');
     $this->cronRun();
 

--- a/xmlsitemap_node/xmlsitemap_node.module
+++ b/xmlsitemap_node/xmlsitemap_node.module
@@ -150,7 +150,7 @@ function xmlsitemap_node_deny_access(array $link, array $context = array()) {
   // Allow other modules to alter the site map link presave.
   backdrop_alter('xmlsitemap_link_presave', $link, $context);
 
-  // Save or update a site map link which will be overwritten in Backdrop cron job.
+  // Save or update a site map link which will be overwritten in cron job.
   xmlsitemap_link_save($link, $context);
 }
 

--- a/xmlsitemap_taxonomy/tests/xmlsitemap_taxonomy.test
+++ b/xmlsitemap_taxonomy/tests/xmlsitemap_taxonomy.test
@@ -49,9 +49,9 @@ class XMLSitemapTaxonomyFunctionalTest extends XMLSitemapTestHelper {
       'xmlsitemap[status]' => '1',
       'xmlsitemap[priority]' => '1.0',
     );
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, 'Save');
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, 'Save vocabulary');
     $this->assertText("Created new vocabulary {$edit['name']}.");
-    $vocabulary = taxonomy_vocabulary_machine_name_load($edit['machine_name']);
+    $vocabulary = taxonomy_vocabulary_load($edit['machine_name']);
 
     $edit = array(
       'name' => $this->randomName(),

--- a/xmlsitemap_taxonomy/tests/xmlsitemap_taxonomy.test
+++ b/xmlsitemap_taxonomy/tests/xmlsitemap_taxonomy.test
@@ -4,6 +4,9 @@
  * Unit tests for the xmlsitemap_taxonomy module.
  */
 
+// Temporarily include the parent class until core provides test autoloading.
+include_once(__DIR__ . '/../../tests/xmlsitemap.test');
+
 /**
  * Functional Test.
  */

--- a/xmlsitemap_user/tests/xmlsitemap_user.test
+++ b/xmlsitemap_user/tests/xmlsitemap_user.test
@@ -4,6 +4,9 @@
  * Unit tests for the xmlsitemap_user module.
  */
 
+// Temporarily include the parent class until core provides test autoloading.
+include_once(__DIR__ . '/../../tests/xmlsitemap.test');
+
 /**
  * Tests for User Functional.
  */


### PR DESCRIPTION
This gets _all_ tests passing in the 1.x-1.x branch of XML Sitemap.

Fixes https://github.com/backdrop-contrib/xmlsitemap/issues/28
Fixes https://github.com/backdrop-contrib/xmlsitemap/issues/29
Fixes https://github.com/backdrop-contrib/xmlsitemap/issues/59
Fixes https://github.com/backdrop-contrib/xmlsitemap/issues/104